### PR TITLE
Add back font-family syncing.

### DIFF
--- a/src/plugins/sync-font/client.js
+++ b/src/plugins/sync-font/client.js
@@ -20,6 +20,7 @@ module.exports = function clientSyncFont(client) {
 			}
 		}
 		document.documentElement.style.fontSize = size;
+		document.body.style.fontFamily = font.family;
 		if (font.dyslexic) {
 			document.body.classList.add('vui-dyslexic');
 		}


### PR DESCRIPTION
Seems like `font-family` syncing was removed accidentally.

https://github.com/Brightspace/ifrau/commit/ad93cc33d2f5cd22cc7bb8d7039589d5d0b40afd#diff-8340eb61a673fe41c70da8c2cff2528aL11
